### PR TITLE
Do not cater to broken Python environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,7 @@ from wagtaillinkchecker import __version__
 with open('README.rst', 'r') as f:
     readme = f.read()
 
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-    from setuptools import setup, find_packages
+from setuptools import setup, find_packages
 
 setup(
     name='wagtail-linkchecker',


### PR DESCRIPTION
Setuptools+pip has been around for almost eight years now. Catering to broken Python environments where there is no setuptools or only distutils only puts an additional burden on you and gives people the false impression that not having setuptools is acceptable.
