### PR TITLE
Support Django 3

### DIFF
--- a/wagtaillinkchecker/views.py
+++ b/wagtaillinkchecker/views.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 
+from functools import lru_cache
+
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect, render
-from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext_lazy as _
 from wagtail import __version__ as WAGTAIL_VERSION
 


### PR DESCRIPTION
A small fix to make wagtaillinkchecker work with Django 3 since they removed compatibility with Python 2. This fix however set the minimal version of Python to 3.2+.