### PR TITLE
Reduce Celery version restrictions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         'wagtail>=1.0',
         'requests>=2.9.1',
-        'celery>=4.0,<4.1'
+        'celery>=4.0,<5'
     ],
     zip_safe=False,
     license='BSD License',


### PR DESCRIPTION
The previous celery version specification obligates the user to use a 4.0.x version of Celery. The most recent version that is compatible is 4.0.2, which was released around 3-4 years ago and has been superseded by other versions. Celery is currently up to 4.4.