### PR TITLE
- Fix for integrating with other apps

### DIFF
--- a/wagtaillinkchecker/__init__.py
+++ b/wagtaillinkchecker/__init__.py
@@ -1,8 +1,3 @@
-from wagtaillinkchecker.celery import app
-
-
-__all__ = ['app']
-
 __version__ = '0.1.0'
 
 default_app_config = 'wagtaillinkchecker.apps.WagtailLinkchekerAppConfig'

--- a/wagtaillinkchecker/celery.py
+++ b/wagtaillinkchecker/celery.py
@@ -1,8 +1,0 @@
-from celery import Celery
-from django.conf import settings
-
-app = Celery('wagtaillinkchecker')
-
-app.config_from_object('django.conf:settings', namespace='CELERY')
-
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)


### PR DESCRIPTION
I have fixed the connection with external apps. I had the same problem as this issue - https://github.com/neon-jungle/wagtail-linkchecker/issues/7

Turns out the problem was that this repo creates a new Celery instance with name `wagtaillinkchecker` and when, integrated the main repo's Celery app was not able to find the shared_tasks, thus hanging.

Tested and works on 
```
Django==3.1.5
wagtail==2.11.3
```