### PR TITLE
Add some options to the management command

### DIFF
--- a/wagtaillinkchecker/management/commands/linkcheck.py
+++ b/wagtaillinkchecker/management/commands/linkcheck.py
@@ -31,9 +31,10 @@ class Command(BaseCommand):
         site = Site.objects.filter(is_default_site=True).first()
         pages = site.root_page.get_descendants(inclusive=True).live().public()
         run_sync = kwargs.get('run_synchronously') or False
+        verbosity = kwargs.get('verbosity') or 1
 
         print(f'Scanning {len(pages)} pages...')
-        scan = broken_link_scan(site, run_sync)
+        scan = broken_link_scan(site, run_sync, verbosity)
         broken_links = ScanLink.objects.filter(scan=scan, crawled=True)
         print(f'Found {len(broken_links)} broken links.')
 

--- a/wagtaillinkchecker/management/commands/linkcheck.py
+++ b/wagtaillinkchecker/management/commands/linkcheck.py
@@ -15,6 +15,12 @@ else:
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--do-not-send-mail',
+            action='store_true',
+            help='Do not send mails when finding broken links',
+        )
 
     def handle(self, *args, **kwargs):
         site = Site.objects.filter(is_default_site=True).first()
@@ -23,6 +29,10 @@ class Command(BaseCommand):
         scan = broken_link_scan(site)
         broken_links = ScanLink.objects.filter(scan=scan, crawled=True)
         print(f'Found {len(broken_links)} broken links.')
+
+        if kwargs['do-not-send-mail']:
+            print(f'Will not send any emails')
+            return
 
         messages = []
         for page in pages:

--- a/wagtaillinkchecker/management/commands/linkcheck.py
+++ b/wagtaillinkchecker/management/commands/linkcheck.py
@@ -21,16 +21,23 @@ class Command(BaseCommand):
             action='store_true',
             help='Do not send mails when finding broken links',
         )
+        parser.add_argument(
+            '--run-synchronously',
+            action='store_true',
+            help='Run checks synchronously (avoid the need for Celery)',
+        )
 
     def handle(self, *args, **kwargs):
         site = Site.objects.filter(is_default_site=True).first()
         pages = site.root_page.get_descendants(inclusive=True).live().public()
+        run_sync = kwargs.get('run_synchronously') or False
+
         print(f'Scanning {len(pages)} pages...')
-        scan = broken_link_scan(site)
+        scan = broken_link_scan(site, run_sync)
         broken_links = ScanLink.objects.filter(scan=scan, crawled=True)
         print(f'Found {len(broken_links)} broken links.')
 
-        if kwargs['do-not-send-mail']:
+        if kwargs.get('do_not_send_mail'):
             print(f'Will not send any emails')
             return
 

--- a/wagtaillinkchecker/models.py
+++ b/wagtaillinkchecker/models.py
@@ -106,7 +106,7 @@ class ScanLink(models.Model):
     def check_link(self, run_sync=False):
         from wagtaillinkchecker.tasks import check_link
         if run_sync:
-            check_link((self.pk, ))
+            check_link(self.pk)
         else:
             check_link.apply_async((self.pk, ))
 

--- a/wagtaillinkchecker/models.py
+++ b/wagtaillinkchecker/models.py
@@ -1,3 +1,4 @@
+from sys import version
 from django.db import models
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
@@ -103,12 +104,12 @@ class ScanLink(models.Model):
     def page_is_deleted(self):
         return self.page_deleted and self.page_slug
 
-    def check_link(self, run_sync=False):
+    def check_link(self, run_sync=False, verbosity=1):
         from wagtaillinkchecker.tasks import check_link
         if run_sync:
-            check_link(self.pk)
+            check_link(self.pk, verbosity=verbosity)
         else:
-            check_link.apply_async((self.pk, ))
+            check_link.apply_async((self.pk, verbosity))
 
 
 @receiver(pre_delete, sender=Page)

--- a/wagtaillinkchecker/models.py
+++ b/wagtaillinkchecker/models.py
@@ -106,10 +106,11 @@ class ScanLink(models.Model):
 
     def check_link(self, run_sync=False, verbosity=1):
         from wagtaillinkchecker.tasks import check_link
+
         if run_sync:
-            check_link(self.pk, verbosity=verbosity)
+            check_link(self.pk, run_sync=run_sync, verbosity=verbosity)
         else:
-            check_link.apply_async((self.pk, verbosity))
+            check_link.apply_async((self.pk, run_sync, verbosity))
 
 
 @receiver(pre_delete, sender=Page)

--- a/wagtaillinkchecker/models.py
+++ b/wagtaillinkchecker/models.py
@@ -103,9 +103,12 @@ class ScanLink(models.Model):
     def page_is_deleted(self):
         return self.page_deleted and self.page_slug
 
-    def check_link(self):
+    def check_link(self, run_sync=False):
         from wagtaillinkchecker.tasks import check_link
-        check_link.apply_async((self.pk, ))
+        if run_sync:
+            check_link((self.pk, ))
+        else:
+            check_link.apply_async((self.pk, ))
 
 
 @receiver(pre_delete, sender=Page)

--- a/wagtaillinkchecker/scanner.py
+++ b/wagtaillinkchecker/scanner.py
@@ -128,6 +128,6 @@ def broken_link_scan(site, run_sync=False, verbosity=1):
             return
         except ScanLink.DoesNotExist:
             link = ScanLink.objects.create(url=page.full_url, page=page, scan=scan)
-            link.check_link(run_sync)
+            link.check_link(run_sync, verbosity=verbosity)
 
     return scan

--- a/wagtaillinkchecker/scanner.py
+++ b/wagtaillinkchecker/scanner.py
@@ -114,7 +114,7 @@ def clean_url(url, site):
     return url
 
 
-def broken_link_scan(site):
+def broken_link_scan(site, run_sync=False, ):
     from wagtaillinkchecker.models import Scan, ScanLink
     pages = site.root_page.get_descendants(inclusive=True).live().public()
     scan = Scan.objects.create(site=site)
@@ -125,6 +125,6 @@ def broken_link_scan(site):
             return
         except ScanLink.DoesNotExist:
             link = ScanLink.objects.create(url=page.full_url, page=page, scan=scan)
-            link.check_link()
+            link.check_link(run_sync)
 
     return scan

--- a/wagtaillinkchecker/scanner.py
+++ b/wagtaillinkchecker/scanner.py
@@ -114,14 +114,17 @@ def clean_url(url, site):
     return url
 
 
-def broken_link_scan(site, run_sync=False, ):
+def broken_link_scan(site, run_sync=False, verbosity=1):
     from wagtaillinkchecker.models import Scan, ScanLink
     pages = site.root_page.get_descendants(inclusive=True).live().public()
     scan = Scan.objects.create(site=site)
 
     for page in pages:
         try:
-            ScanLink.objects.get(url=page.full_url, scan=scan)
+            url = page.full_url
+            if verbosity > 1:
+                print(f"Checking {url}")
+            ScanLink.objects.get(url=url, scan=scan)
             return
         except ScanLink.DoesNotExist:
             link = ScanLink.objects.create(url=page.full_url, page=page, scan=scan)

--- a/wagtaillinkchecker/tasks.py
+++ b/wagtaillinkchecker/tasks.py
@@ -31,7 +31,7 @@ def check_link(link_pk, run_sync=False, verbosity=1, ):
         for anchor in anchors:
             link_href = anchor.get('href')
             link_href = clean_url(link_href, site)
-            if verbosity > 2:
+            if verbosity > 1:
                 print(f"cleaned link_href: {link_href}")
             if link_href:
                 try:
@@ -43,7 +43,7 @@ def check_link(link_pk, run_sync=False, verbosity=1, ):
         for image in images:
             image_src = image.get('src')
             image_src = clean_url(image_src, site)
-            if verbosity > 2:
+            if verbosity > 1:
                 print(f"cleaned image_src: {image_src}")
             if image_src:
                 try:

--- a/wagtaillinkchecker/tasks.py
+++ b/wagtaillinkchecker/tasks.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 
 @shared_task
-def check_link(link_pk):
+def check_link(link_pk, verbosity=1):
     link = ScanLink.objects.get(pk=link_pk)
     site = link.scan.site
     url = get_url(link.url, link.page, site)

--- a/wagtaillinkchecker/tasks.py
+++ b/wagtaillinkchecker/tasks.py
@@ -9,11 +9,12 @@ from django.utils import timezone
 
 
 @shared_task
-def check_link(link_pk, verbosity=1):
+def check_link(link_pk, run_sync=False, verbosity=1, ):
     link = ScanLink.objects.get(pk=link_pk)
     site = link.scan.site
     url = get_url(link.url, link.page, site)
     link.status_code = url.get('status_code')
+
     if url['error']:
         link.broken = True
         link.error_text = url['error_message']
@@ -30,20 +31,24 @@ def check_link(link_pk, verbosity=1):
         for anchor in anchors:
             link_href = anchor.get('href')
             link_href = clean_url(link_href, site)
+            if verbosity > 2:
+                print(f"cleaned link_href: {link_href}")
             if link_href:
                 try:
                     new_link = link.scan.add_link(page=link.page, url=link_href)
-                    new_link.check_link()
+                    new_link.check_link(run_sync, verbosity)
                 except IntegrityError:
                     pass
 
         for image in images:
             image_src = image.get('src')
             image_src = clean_url(image_src, site)
+            if verbosity > 2:
+                print(f"cleaned image_src: {image_src}")
             if image_src:
                 try:
                     new_link = link.scan.add_link(page=link.page, url=image_src)
-                    new_link.check_link()
+                    new_link.check_link(run_sync, verbosity)
                 except IntegrityError:
                     pass
     link.crawled = True


### PR DESCRIPTION
This PR adds a bunch of optional options to make using the `linkcheck` management command easier.

Specifically: 
* Pass `--do-not-send-mail` to check the broken links but skip the mail sending part
* Pass `--run-synchronously` to run the checks synchronously one after the other so you won't need to install Celery to use this package
* Pass `-v 2` or `--verbosity=2` (actually any value > 1) to see some more info about what happens when running the command